### PR TITLE
Update branch-alias to 2.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.x-dev"
+            "dev-master": "2.x-dev"
         },
         "project-files": []
     },


### PR DESCRIPTION
Update branch-alias to 2.x-dev so that requiring `1.x-dev` installs `1.x-dev` rather than `dev-master`