### PR TITLE
MNT Allow installation with any version of PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "https://www.silverstripe.org",
     "license": "BSD-3-Clause",
     "require": {
-        "php": "^7.3 || 8.0",
+        "php": "^7.3 || ^8.0",
         "silverstripe/recipe-plugin": "^1",
         "silverstripe/recipe-cms": "4.10.x-dev",
         "silverstripe/documentconverter": "2.2.x-dev",


### PR DESCRIPTION
The old constraint only allows installation on PHP 8.0.0 ... I was blocked from installing on PHP 8.0.14. Other recipes use this more sensible constraint.